### PR TITLE
Secure Forcepoint SMC API transport

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright Martin Ohl 2021-2025
+   Copyright Martin Ohl 2021-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Forcepoint
-Copyright Martin Ohl 2021-2025
+Copyright Martin Ohl 2021-2026

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Forcepoint
 
-Publisher: Martin Ohl \
-Connector Version: 2.0.0 \
-Product Vendor: Forcepoint \
-Product Name: Forcepoint NGFW \
+Publisher: Martin Ohl <br>
+Connector Version: 2.0.0 <br>
+Product Vendor: Forcepoint <br>
+Product Name: Forcepoint NGFW <br>
 Minimum Product Version: 5.5.0
 
 This app integrates with Forcepoint Firewall
+
+The connector sends the SMC API authentication key only over HTTPS. TLS certificate verification
+is enabled by default; install a CA-issued certificate on the SMC or add its issuing certificate
+to the SOAR trust store before connecting. Disable verification only when an administrator has
+explicitly accepted the man-in-the-middle risk.
 
 ### Configuration variables
 
@@ -22,14 +27,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [block ip](#action-block-ip) - Block an IP
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 Tests api connectivity by making a login/logout call to SMC api.
@@ -46,7 +51,7 @@ No Output
 
 Block an IP
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 Updates Bad IP list.
@@ -75,7 +80,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright Martin Ohl 2021-2025
+# Copyright Martin Ohl 2021-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/forcepoint.json
+++ b/forcepoint.json
@@ -8,14 +8,14 @@
     "logo_dark": "logo_forcepoint_dark.svg",
     "product_name": "Forcepoint NGFW",
     "product_version_regex": ".*",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "publisher": "Martin Ohl",
     "contributors": [
         {
             "name": "Nikhilesh Chaudhari"
         }
     ],
-    "license": "Copyright Martin Ohl 2021-2025",
+    "license": "Copyright Martin Ohl 2021-2026",
     "app_version": "2.0.0",
     "utctime_updated": "2018-11-02T21:56:43.000000Z",
     "package_name": "phantom_forcepoint",
@@ -142,5 +142,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/forcepoint.json
+++ b/forcepoint.json
@@ -34,7 +34,7 @@
             "data_type": "boolean",
             "description": "Verify server certificate",
             "order": 1,
-            "default": false
+            "default": true
         },
         "base_port": {
             "required": true,

--- a/forcepoint_connector.py
+++ b/forcepoint_connector.py
@@ -45,9 +45,9 @@ class ForcepointConnector(BaseConnector):
         self._force_port = config.get("base_port")
         self._force_version = config.get("base_version")
         self._force_auth_key = config.get("auth_key")
-        self._verify = config.get(phantom.APP_JSON_VERIFY, False)
+        self._verify = config.get(phantom.APP_JSON_VERIFY, True)
 
-        self.url = "http://" + self._force_url + ":" + self._force_port + "/" + self._force_version
+        self.url = "https://" + self._force_url + ":" + self._force_port + "/" + self._force_version
 
         session = requests.session()
 

--- a/forcepoint_connector.py
+++ b/forcepoint_connector.py
@@ -1,6 +1,6 @@
 # File: forcepoint_connector.py
 #
-# Copyright Martin Ohl 2021-2025
+# Copyright Martin Ohl 2021-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,0 +1,4 @@
+The connector sends the SMC API authentication key only over HTTPS. TLS certificate verification
+is enabled by default; install a CA-issued certificate on the SMC or add its issuing certificate
+to the SOAR trust store before connecting. Disable verification only when an administrator has
+explicitly accepted the man-in-the-middle risk.

--- a/readme.html
+++ b/readme.html
@@ -1,5 +1,5 @@
 <!-- File: readme.html
-  Copyright Martin Ohl 2021-2025
+  Copyright Martin Ohl 2021-2026
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Send SMC API credentials only over HTTPS and verify the server certificate by default.
+* Send SMC API credentials only over HTTPS and verify the server certificate by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Send SMC API credentials only over HTTPS and verify the server certificate by default.
+* - Send SMC API credentials only over HTTPS and verify the server certificate by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Send SMC API credentials only over HTTPS and verify the server certificate by default.


### PR DESCRIPTION
## Summary\n\n- send the Forcepoint SMC authentication key only over HTTPS\n- enable server-certificate verification by default and document the trust-store requirement\n- refresh the central hook and Python 3.9/3.13 packaging baseline\n\nTracks [PAPP-38180](https://splunk.atlassian.net/browse/PAPP-38180) and PSAAS-30908.\n\n## Quality gate\n\n- local pre-commit: passed\n- hosted pre-commit and compile: pending\n\nThis PR was created entirely with Codex (AI) assistance.

## Tracking

- PAPP: PAPP-38180
- PSAAS: PSAAS-30908
- Written by Codex.